### PR TITLE
Update Go to 1.26.5 and modernize lint CI

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -1,0 +1,36 @@
+name: GitHub Actions Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  actions-security:
+    name: Check workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install aqua tools
+        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.62.0
+
+      - name: Check action pinning
+        run: pinact run --check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Audit workflows
+        run: zizmor --format github .
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,43 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
-  test-lint:
-    uses: blck-snwmn/share-workflows/.github/workflows/reusable-go-lint.yml@78245d99cf579c6a572643a85cdcf110e613e705 # main
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Test
+        run: go test ./... --shuffle=on --parallel=10 --p=10
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.12.2
+          args: --config=.golangci.yml

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,8 +39,10 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
-      - name: Lint
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+      - name: Install aqua tools
+        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
         with:
-          version: v2.12.2
-          args: --config=.golangci.yml
+          aqua_version: v2.62.0
+
+      - name: Lint
+        run: golangci-lint run --config=.golangci.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+linters:
+  enable:
+    - gosec

--- a/actions.go
+++ b/actions.go
@@ -20,7 +20,7 @@ type Action interface {
 
 func NewAction(ctx context.Context, args []string, q *db.Queries) (Action, error) {
 	if len(args) < 2 {
-		return nil, fmt.Errorf("Usage: <command> <args>")
+		return nil, fmt.Errorf("usage: <command> <args>")
 	}
 
 	command := args[1]
@@ -29,7 +29,7 @@ func NewAction(ctx context.Context, args []string, q *db.Queries) (Action, error
 	switch command {
 	case "add":
 		if len(commandArgs) < 2 {
-			return nil, fmt.Errorf("Usage: add <title> <description>")
+			return nil, fmt.Errorf("usage: add <title> <description>")
 		}
 		title := commandArgs[0]
 		desc := commandArgs[1]
@@ -38,7 +38,7 @@ func NewAction(ctx context.Context, args []string, q *db.Queries) (Action, error
 		return &ListAction{q: q}, nil
 	case "get":
 		if len(commandArgs) < 1 {
-			return nil, fmt.Errorf("Usage: get <id>")
+			return nil, fmt.Errorf("usage: get <id>")
 		}
 		id, err := strconv.Atoi(commandArgs[0])
 		if err != nil {
@@ -47,7 +47,7 @@ func NewAction(ctx context.Context, args []string, q *db.Queries) (Action, error
 		return &GetAction{q: q, id: int64(id)}, nil
 	case "update":
 		if len(commandArgs) < 4 {
-			return nil, fmt.Errorf("Usage: update <id> <title> <description> <is_done>")
+			return nil, fmt.Errorf("usage: update <id> <title> <description> <is_done>")
 		}
 		id, err := strconv.Atoi(commandArgs[0])
 		if err != nil {
@@ -60,7 +60,7 @@ func NewAction(ctx context.Context, args []string, q *db.Queries) (Action, error
 		return &UpdateAction{q: q, id: int64(id), title: commandArgs[1], desc: commandArgs[2], isDone: isDone}, nil
 	case "delete":
 		if len(commandArgs) < 1 {
-			return nil, fmt.Errorf("Usage: delete <id>")
+			return nil, fmt.Errorf("usage: delete <id>")
 		}
 		id, err := strconv.Atoi(commandArgs[0])
 		if err != nil {
@@ -69,7 +69,7 @@ func NewAction(ctx context.Context, args []string, q *db.Queries) (Action, error
 		return &DeleteAction{q: q, id: int64(id)}, nil
 	case "done":
 		if len(commandArgs) < 1 {
-			return nil, fmt.Errorf("Usage: done <id>")
+			return nil, fmt.Errorf("usage: done <id>")
 		}
 		id, err := strconv.Atoi(commandArgs[0])
 		if err != nil {

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -3,5 +3,6 @@ registries:
   - type: standard
     ref: v4.542.0 # renovate: depName=aquaproj/aqua-registry
 packages:
+  - name: golangci/golangci-lint@v2.12.2
   - name: suzuki-shunsuke/pinact@v4.1.0
   - name: zizmorcore/zizmor@v1.28.0

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+registries:
+  - type: standard
+    ref: v4.542.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+  - name: suzuki-shunsuke/pinact@v4.1.0
+  - name: zizmorcore/zizmor@v1.28.0

--- a/cmd/createdb/main.go
+++ b/cmd/createdb/main.go
@@ -14,7 +14,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			log.Printf("close database: %v", err)
+		}
+	}()
 
 	// create tables
 	if _, err := conn.ExecContext(context.Background(), db.DDL); err != nil {

--- a/cmd/todo/main.go
+++ b/cmd/todo/main.go
@@ -19,7 +19,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			log.Printf("close database: %v", err)
+		}
+	}()
 
 	q := db.New(conn)
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/blck-snwmn/hello-sqlite
 
-go 1.21
+go 1.26.5
 
 require github.com/mattn/go-sqlite3 v1.14.48


### PR DESCRIPTION
## Summary

- update the `go` directive from 1.21 to 1.26.5
- replace the outdated shared Go workflow with repository-local test and lint jobs
- update to `actions/setup-go` v7 and manage golangci-lint v2.12.2 through aqua
- add pinact and zizmor security checks managed by aqua
- fix existing lint findings exposed by the newer golangci-lint release

## Why

The previous lint job installed golangci-lint v1.64.8, which was built with Go 1.24. It rejected the module after its target version moved to Go 1.26.5 before lint analysis could start.

## Validation

- `go test ./... --shuffle=on --parallel=10 --p=10`
- aqua-managed `golangci-lint v2.12.2 run --config=.golangci.yml`
- `pinact run --check`
- `zizmor --format github .`
- `git diff --check`
